### PR TITLE
Reminder of Report Types

### DIFF
--- a/threatcmd.go
+++ b/threatcmd.go
@@ -8,7 +8,7 @@ import (
 
 var (
     //target string
-    report = kingpin.Arg("report", "What to report on").Required().String()
+    report = kingpin.Arg("report", "What to report on [av, domain email, file, ip]").Required().String()
     target = kingpin.Arg("target", "What to report on").Required().String()
 
 )


### PR DESCRIPTION
I kept trying to use threatcmd and could never remember if the report type I wanted was `hash` or `file`, `av` or `malware`, etc. I thought it would be easier to remind users of available targets on the command line.
